### PR TITLE
feat: #20 added support for streams on delete and restore actions

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -238,7 +238,13 @@ class Elements extends Component
 
         foreach ($processed as $action) {
             if ($action['type'] === $type) {
-                $data[] = Json::decode($action['data']);
+                // parse potential stream-resources originating from the query
+                if (gettype($action['data']) === 'resource'
+                    && get_resource_type($action['data']) === 'stream') {
+                    $data[] = Json::decode(stream_get_contents($action['data']));
+                } else {
+                    $data[] = Json::decode($action['data']);
+                }
             }
         }
 


### PR DESCRIPTION
Originating from issue #20, this change adds support for streams on delete an restore actions which originate from the query executed in the updated function. It is not clear why the query returns streams as parts of its response. However the change just does a type checking and in case it is a stream, it will get its contents. If it is not a stream, then the current implementation is used. This enusres backward-compatibility.